### PR TITLE
Update sqlc and base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@
 #   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #   SOFTWARE.
 
-FROM golang:1.19-alpine \
+FROM golang:1.21-alpine \
   AS build
 
 ENV USER=appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN apk update \
  && update-ca-certificates
 
 RUN CGO_ENABLED=0 GOOS=linux \
-    go install github.com/kyleconroy/sqlc/cmd/sqlc@v1.18.0 \
+    go install github.com/kyleconroy/sqlc/cmd/sqlc@v1.25.0 \
  && /go/bin/sqlc version
 
 FROM scratch \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN apk update \
  && update-ca-certificates
 
 RUN CGO_ENABLED=0 GOOS=linux \
-    go install github.com/kyleconroy/sqlc/cmd/sqlc@v1.25.0 \
+    go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.25.0 \
  && /go/bin/sqlc version
 
 FROM scratch \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 
 # SQLC
 
-This project is proving a `docker` version of the `sqlc` tool.
+This project is providing a `docker` version of the `sqlc` tool.
+
+See https://sqlc.dev/ for more information.


### PR DESCRIPTION
This PR introduces the following changes:

* updates the base image to `golang:1.21-alpine`
* updates sqlc to the currently latest version `v1.25.0`